### PR TITLE
Raise Http404 rather than return HttpResponseNotFound

### DIFF
--- a/wagtail_qrcode/views.py
+++ b/wagtail_qrcode/views.py
@@ -15,6 +15,5 @@ def qr_code_page_view(request):
     if hasattr(page, "qr_code_usage"):
         page.qr_code_usage += 1
         page.save()
-        return HttpResponseRedirect(page.url)
-    else:
-        raise Http404
+
+    return HttpResponseRedirect(page.url)

--- a/wagtail_qrcode/views.py
+++ b/wagtail_qrcode/views.py
@@ -7,9 +7,9 @@ def qr_code_page_view(request):
     try:
         page_id = int(request.GET.get("id"))
     except ValueError:
-        raise Http404
+        raise Http404("Page ID not valid, incorrect value")
     except TypeError:
-        raise Http404
+        raise Http404("Page ID not present, incorrect type")
 
     try:
         page = Page.objects.get(id=page_id).specific

--- a/wagtail_qrcode/views.py
+++ b/wagtail_qrcode/views.py
@@ -4,7 +4,12 @@ from wagtail.models import Page
 
 def qr_code_page_view(request):
     """QR code redirect view."""
-    page_id = int(request.GET.get("id"))
+    try:
+        page_id = int(request.GET.get("id"))
+    except ValueError:
+        raise Http404
+    except TypeError:
+        raise Http404
 
     try:
         specific_cls = Page.objects.get(id=page_id).specific_class

--- a/wagtail_qrcode/views.py
+++ b/wagtail_qrcode/views.py
@@ -12,8 +12,7 @@ def qr_code_page_view(request):
         raise Http404
 
     try:
-        specific_cls = Page.objects.get(id=page_id).specific_class
-        page = specific_cls.objects.get(id=page_id)
+        page = Page.objects.get(id=page_id).specific()
     except Page.DoesNotExist:
         raise Http404
 

--- a/wagtail_qrcode/views.py
+++ b/wagtail_qrcode/views.py
@@ -1,4 +1,4 @@
-from django.http import HttpResponseNotFound, HttpResponseRedirect
+from django.http import Http404, HttpResponseRedirect
 from wagtail.models import Page
 
 
@@ -10,11 +10,11 @@ def qr_code_page_view(request):
         specific_cls = Page.objects.get(id=page_id).specific_class
         page = specific_cls.objects.get(id=page_id)
     except Page.DoesNotExist:
-        return HttpResponseNotFound("Page not found")
+        raise Http404
 
     if hasattr(page, "qr_code_usage"):
         page.qr_code_usage += 1
         page.save()
         return HttpResponseRedirect(page.url)
-
-    return HttpResponseNotFound("Page not found")
+    else:
+        raise Http404

--- a/wagtail_qrcode/views.py
+++ b/wagtail_qrcode/views.py
@@ -12,7 +12,7 @@ def qr_code_page_view(request):
         raise Http404
 
     try:
-        page = Page.objects.get(id=page_id).specific()
+        page = Page.objects.get(id=page_id).specific
     except Page.DoesNotExist:
         raise Http404
 


### PR DESCRIPTION
The Django docs recommend that it is better to raise the Http404 error rather than return HttpResponseNotFound so as to provide a more consistent 404 page across a website:

https://docs.djangoproject.com/en/5.2/topics/http/views/#the-http404-exception

This update replaces HttpResponseNotFound with Http404 and provides additional error handling around the parsing the of "id" parameter so as to provide a smoother experience for public visitors to a site. Additional information is given with these errors for debugging purposes.

The two lines retrieving "specific_class" and then the page itself have been replaced with a single line:

`page = Page.objects.get(id=page_id).specific`

in keeping with more common Wagtail practice.

The call to update "qr_code_usage" has been separated out from returning the page so as to allow a page to be returned whenever there is a valid URL, even if that specific page no longer integrates the QR code usage count.

The redirect to the page.url ends the view function to allow any other error handling to be passed onto the specific page view itself.